### PR TITLE
Enhancing file serving

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,20 +5,25 @@ Simple HTTP server written in bash script
 == Requirements
 
 * bash
-* nc (netcat)
+* ncat (nmap)
 * file
 * wc
 * cat
+* upnpc (MiniUPnP)
 
 == Usage
 
-./httpd.bash [port]
+./httpd.bash <address> [port]
 
+<address> is the adress of the eth that will receive requests. Needed to configure port foward under NAT.
+Use ipconfig to check it out or use a dash '-' to ignore UPnP.
 (port is default to 3000)
 
 == Warning
 
 This isn't secure. Don't export to internet.
+
+Note from Lisias: I did it, since the UPnP port forward setup. But I used an expandable Raspberry PI box, without any usefull or sensitive data.
 
 == License
 

--- a/README.txt
+++ b/README.txt
@@ -23,7 +23,7 @@ Use ipconfig to check it out or use a dash '-' to ignore UPnP.
 
 This isn't secure. Don't export to internet.
 
-Note from Lisias: I did it, since the UPnP port forward setup. But I used an expandable Raspberry PI box, without any usefull or sensitive data.
+Note from Lisias: I did it, since the UPnP port forward setup. But I used an expendable Raspberry PI box, without any usefull or sensitive data.
 
 == License
 

--- a/README.txt
+++ b/README.txt
@@ -13,11 +13,12 @@ Simple HTTP server written in bash script
 
 == Usage
 
-./httpd.bash <address> [port]
+./httpd.bash [port] <address> [external port]
 
-<address> is the adress of the eth that will receive requests. Needed to configure port foward under NAT.
-Use ipconfig to check it out or use a dash '-' to ignore UPnP.
 (port is default to 3000)
+<address> is the adress of the eth that will receive requests. Needed to configure port foward under NAT.
+    Use ipconfig to check it out or use a dash '-' to ignore UPnP.
+(external port is default to 8080)
 
 == Warning
 

--- a/httpd.bash
+++ b/httpd.bash
@@ -2,11 +2,11 @@
 # httpd.bash: simple HTTP server written in bash script
 #
 # usage:
-#   ./httpd.bash <address> [port] [external port]
+#   ./httpd.bash [port] <address> [external port]
 #
-#   <address> is the adress of the eth that will receive requests. Needed to configure port foward under NAT.
-#   Use ipconfig to check it out or use a dash '-' to ignore UPnP.
 #   (port is default to 3000)
+#   <address> is the adress of the eth that will receive requests. Needed to configure port foward under NAT.
+#       Use ipconfig to check it out or use a dash '-' to ignore UPnP.
 #   (external port is default to 8080)
 #
 # requires:
@@ -85,9 +85,9 @@ export -f content_type content_length ok_200 not_implemented_501 not_found_404 d
 export CRLF SERVERNAME
 
 FINISHCMD=""
-if [ "${1}" != "-" -a "${1}" != "" ]; then
-    upnpc -a ${1} ${3:8080} ${2:-3000} tcp 14400
-    FINISHCMD="upnpc -d ${3:-8080} tcp "
+if [ "${2}" != "-" -a "${2}" != "" ]; then
+    upnpc -a ${2} ${1:-3000} ${3:-8080} tcp 14400
+    FINISHCMD="upnpc -d ${3:-8080} tcp"
 fi
 finish() {
     echo ""
@@ -103,5 +103,5 @@ export FINISHCMD
 trap 'finish; exit' INT
 echo 'Ctrl-C to shutdown server'
 while :; do
-    ncat -v -lk -p ${2:-3000} -c 'bash -c run'
+    ncat -v -lk -p ${1:-3000} -c 'bash -c run'
 done

--- a/httpd.bash
+++ b/httpd.bash
@@ -4,12 +4,12 @@
 #   ./httpd.bash [port]
 #   (port is default to 3000)
 # requires:
-#   bash, nc (netcat), file, wc, cat
+#   bash, ncat (nmap), file, wc, cat, upnpc
 # warning:
 #   This isn't secure. Don't export to internet.
 
 readonly CRLF=$'\r\n'
-readonly SERVERNAME='httpd.bash/0.01'
+readonly SERVERNAME='httpd.bash/0.2-LST'
 
 function content_type() {
     local file=$1
@@ -49,11 +49,13 @@ function not_found_404() {
 
 function dispatch() {
     local method=$1 path=$2
+    echo $method $path >&2
     if [[ $method == GET ]]; then
         [[ $path == /* ]] && path=".$path"
         path=${path#../}
         path=${path//\/..\//}
         [ -d "$path" ] && path="$path/index.html"
+        echo $path >&2
         if [ -f "$path" ]; then
             ok_200 "$path"
         else
@@ -71,12 +73,11 @@ function run() {
     dispatch "$method" "$path"
 }
 
-export -f content_type content_length ok_200 not_implemented_501 \
-  not_found_404 dispatch run
+export -f content_type content_length ok_200 not_implemented_501 not_found_404 dispatch run
 export CRLF SERVERNAME
 
 trap 'echo shutdown.; exit' INT
 echo 'Ctrl-C to shutdown server'
 while :; do
-    nc -l -p ${1:-3000} -c 'bash -c run'
+    ncat -v -lk -p ${2:-3000} -c 'bash -c run'
 done

--- a/httpd.bash
+++ b/httpd.bash
@@ -1,12 +1,19 @@
 #!/bin/bash
 # httpd.bash: simple HTTP server written in bash script
+#
 # usage:
-#   ./httpd.bash [port]
+#   ./httpd.bash <address> [port]
+#
+#   <address> is the adress of the eth that will receive requests. Needed to configure port foward under NAT.
+#   Use ipconfig to check it out or use a dash '-' to ignore UPnP.
 #   (port is default to 3000)
+#
 # requires:
 #   bash, ncat (nmap), file, wc, cat, upnpc
+#
 # warning:
 #   This isn't secure. Don't export to internet.
+#       I enjoy livin' La Vida Loca!! - Lisias :-)
 
 readonly CRLF=$'\r\n'
 readonly SERVERNAME='httpd.bash/0.2-LST'
@@ -75,6 +82,10 @@ function run() {
 
 export -f content_type content_length ok_200 not_implemented_501 not_found_404 dispatch run
 export CRLF SERVERNAME
+
+if [ "${1}" != "-" -a "${1}" != "" ]; then
+    upnpc -a ${1} 8080 ${2:-3000} tcp 14400
+fi
 
 trap 'echo shutdown.; exit' INT
 echo 'Ctrl-C to shutdown server'


### PR DESCRIPTION
(Now doing properly)

This Pull Request enhances file serving by using NMAP's NCAT to handle the connections, using the --keep-alive option.

This keeps the connection alive between requests, allowing multiple file requests being served even on a slow device as a Raspberry PI 2011.12.

It also allows punching a hole on a NAT intranet, what permits serving to the Internet. A temerarious option, but I needed it to a demonstration.

There's a RPi serving it right now on http://home.lisias.net:8080/ for the next few hours (if down, please contact me), when the UPnP drops the fowarding until restart (what I do eventually and/or under request) - a measure to avoid leaving the server unnatended for too much time.

I don't expect the Pull Request to be accepted in the present state. Please fell free to discuss it and propose better solutions!

Thanks!
